### PR TITLE
Fix exclusive access violation in swift 3.2+

### DIFF
--- a/Sources/Extensions.swift
+++ b/Sources/Extensions.swift
@@ -7,7 +7,11 @@ extension Array {
     for i in 0..<(list.count - 1) {
       let j = Int(arc4random_uniform(UInt32(list.count - i))) + i
       if i != j {
-        swap(&list[i], &list[j])
+        #if swift(>=3.2)
+          list.swapAt(i, j)
+        #else
+          swap(&list[i], &list[j])
+        #endif
       }
     }
     return list


### PR DESCRIPTION
This is a warning in Swift 3.2 (i.e. xcode 9) and an error on Swift 4.