### PR TITLE
Update to use with programmatically rendered view

### DIFF
--- a/Sources/Cheers.swift
+++ b/Sources/Cheers.swift
@@ -16,9 +16,9 @@ public class CheerView: UIView {
     stop()
 
     let emitter = CAEmitterLayer()
-    emitter.emitterPosition = CGPoint(x: bounds.width / 2.0, y: 0)
+    emitter.emitterPosition = CGPoint(x: superview!.bounds.width / 2.0, y: 0)
     emitter.emitterShape = kCAEmitterLayerLine
-    emitter.emitterSize = CGSize(width: bounds.width, height: 1)
+    emitter.emitterSize = CGSize(width: superview!.bounds.width, height: 1)
     emitter.renderMode = kCAEmitterLayerAdditive
 
     let colors = config.colors.shuffled()


### PR DESCRIPTION
Added `superview!.bounds...`. 
_Assuming that the person calls `someView.addSubview` before calling the `cheerView.start()`._