### PR TITLE
Make CheerView open to allow subclassing

### DIFF
--- a/Sources/Cheers.swift
+++ b/Sources/Cheers.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 /// The view to show particles
-public class CheerView: UIView {
+open class CheerView: UIView {
   public var config = Config()
   var emitter: CAEmitterLayer?
 


### PR DESCRIPTION
In some cases, subclassing CheerView may be desired, but without the open access level, it isn't possible. This PR fixes that issue.