### PR TITLE
Fix macOS compatibility by using UX* typealiases

### DIFF
--- a/Sources/Common/Configuration.swift
+++ b/Sources/Common/Configuration.swift
@@ -18,7 +18,7 @@ import UIKit
 /// - text: An array of texts
 public enum Particle {
     case confetti(allowedShapes: [ConfettiShape])
-    case image([UIImage])
+    case image([UXImage])
     case text(CGSize, [NSAttributedString])
 
     /// The shape of a piece of confetti.
@@ -39,14 +39,14 @@ public struct Configuration {
     public var particle: Particle = .confetti(allowedShapes: Particle.ConfettiShape.all)
 
     /// The list of available colors. This will be shuffled
-    public var colors: [UIColor] = [
-        UIColor.red,
-        UIColor.green,
-        UIColor.blue,
-        UIColor.yellow,
-        UIColor.purple,
-        UIColor.orange,
-        UIColor.cyan
+    public var colors: [UXColor] = [
+        UXColor.red,
+        UXColor.green,
+        UXColor.blue,
+        UXColor.yellow,
+        UXColor.purple,
+        UXColor.orange,
+        UXColor.cyan
     ]
     
     /// The allowed "color range" for RGB values in each particle.

--- a/Sources/Common/EasyConfetti.swift
+++ b/Sources/Common/EasyConfetti.swift
@@ -12,7 +12,7 @@ import UIKit
 #endif
 
 /// The view to show particles
-public class ConfettiView: UIView {
+public class ConfettiView: UXView {
     public var config = Configuration()
     var emitter: CAEmitterLayer?
     
@@ -50,7 +50,7 @@ public class ConfettiView: UIView {
         // This combination will ensure that all color/image combinations are evenly distributed.
         // For example, if you have only one color, then we still want to make sure
         // that all "allowed" particle types are represented in the result.
-        let combinations = Array<(UIColor, UIImage)>.createAllCombinations(
+        let combinations = Array<(UXColor, UXImage)>.createAllCombinations(
             from: config.colors,
             and: pickImages()
         )
@@ -97,7 +97,7 @@ public class ConfettiView: UIView {
         emitter?.birthRate = 0
     }
     
-    func pickImages() -> [UIImage] {
+    func pickImages() -> [UXImage] {
         let generator = ImageGenerator()
         
         switch config.particle {

--- a/Sources/Common/ImageGenerator.swift
+++ b/Sources/Common/ImageGenerator.swift
@@ -15,8 +15,8 @@ import UIKit
 class ImageGenerator {
     private let size = CGSize(width: 20, height: 20)
 
-    private func generate(block: @escaping (CGContext?) -> Void) -> UIImage? {
-        var image: UIImage?
+    private func generate(block: @escaping (CGContext?) -> Void) -> UXImage? {
+        var image: UXImage?
 #if os(OSX)
         image = NSImage(size: size, flipped: false) { (rect) -> Bool in
             let context = NSGraphicsContext.current!.cgContext
@@ -37,7 +37,7 @@ class ImageGenerator {
         return image
     }
 
-    func generate(size: CGSize, string: NSAttributedString) -> UIImage? {
+    func generate(size: CGSize, string: NSAttributedString) -> UXImage? {
         return generate { context in
             let rect = CGRect(origin: .zero, size: size)
             context?.clear(rect)
@@ -45,7 +45,7 @@ class ImageGenerator {
         }
     }
 
-    func confetti(shape: Particle.ConfettiShape) -> UIImage? {
+    func confetti(shape: Particle.ConfettiShape) -> UXImage? {
         switch shape {
         case .rectangle: return rectangle()
         case .circle: return circle()
@@ -54,42 +54,42 @@ class ImageGenerator {
         }
     }
 
-    private func rectangle() -> UIImage? {
+    private func rectangle() -> UXImage? {
         return generate { context in
             let rect = CGRect(x: 0, y: 0, width: self.size.width, height: self.size.height/2)
-            let path = UIBezierPath(rect: rect)
-            context?.setFillColor(UIColor.white.cgColor)
+            let path = UXBezierPath(rect: rect)
+            context?.setFillColor(UXColor.white.cgColor)
             context?.addPath(path.cgPath)
             context?.fillPath()
         }
     }
 
-    private func circle() -> UIImage? {
+    private func circle() -> UXImage? {
         return generate { context in
             let rect = CGRect(origin: .zero, size: self.size)
-            let path = UIBezierPath(ovalIn: rect)
-            context?.setFillColor(UIColor.white.cgColor)
+            let path = UXBezierPath(ovalIn: rect)
+            context?.setFillColor(UXColor.white.cgColor)
             context?.addPath(path.cgPath)
             context?.fillPath()
         }
     }
 
-    private func triangle() -> UIImage? {
+    private func triangle() -> UXImage? {
         return generate { context in
-            let path = UIBezierPath()
+            let path = UXBezierPath()
             path.move(to: CGPoint(x: self.size.width/2, y: 0))
             path.addLine(to: CGPoint(x: self.size.width, y: self.size.height))
             path.addLine(to: CGPoint(x: 0, y: self.size.height))
             path.close()
-            context?.setFillColor(UIColor.white.cgColor)
+            context?.setFillColor(UXColor.white.cgColor)
             context?.addPath(path.cgPath)
             context?.fillPath()
         }
     }
 
-    private func curvedQuadrilateral() -> UIImage? {
+    private func curvedQuadrilateral() -> UXImage? {
         return generate { context in
-            let path = UIBezierPath()
+            let path = UXBezierPath()
             let rightPoint = CGPoint(x: self.size.width - 5, y: 5)
             let leftPoint = CGPoint(x: self.size.width * 0.5, y: self.size.height - 8)
 
@@ -106,7 +106,7 @@ class ImageGenerator {
             path.addQuadCurve(to: CGPoint.zero,
                               controlPoint: leftPoint)
             path.close()
-            context?.setFillColor(UIColor.white.cgColor)
+            context?.setFillColor(UXColor.white.cgColor)
             context?.addPath(path.cgPath)
             context?.fillPath()
         }

--- a/Sources/macOS/macOS+extensions.swift
+++ b/Sources/macOS/macOS+extensions.swift
@@ -10,10 +10,10 @@
 
 import AppKit
 
-typealias UXImage = NSImage
-typealias UXColor = NSColor
-typealias UXView = NSView
-typealias UXBezierPath = NSBezierPath
+public typealias UXBezierPath = NSBezierPath
+public typealias UXColor = NSColor
+public typealias UXImage = NSImage
+public typealias UXView = NSView
 
 extension NSImage {
     var cgImage: CGImage? {
@@ -58,9 +58,9 @@ extension NSBezierPath {
 
 import UIKit
 
-typealias UXImage = UIImage
-typealias UXColor = UIColor
-typealias UXView = UIView
-typealias UXBezierPath = UIBezierPath
+public typealias UXBezierPath = UIBezierPath
+public typealias UXColor = UIColor
+public typealias UXImage = UIImage
+public typealias UXView = UIView
 
 #endif


### PR DESCRIPTION
## Summary

- Fixed macOS build failure caused by unconditional use of UIKit-specific types (`UIImage`, `UIColor`, `UIView`, `UIBezierPath`)
- Used the existing `UX*` typealiases (`UXImage`, `UXColor`, `UXView`, `UXBezierPath`) throughout the codebase
- Made `UX*` typealiases `public` to support use in public API

## Problem

The package declares macOS support in `Package.swift` but fails to compile on macOS because UIKit types are used directly in source files. These types don't exist on macOS.

## Solution

The codebase already defined platform-agnostic typealiases in `macOS+extensions.swift`:
- `UXImage` → `NSImage` (macOS) / `UIImage` (iOS)
- `UXColor` → `NSColor` (macOS) / `UIColor` (iOS)
- `UXView` → `NSView` (macOS) / `UIView` (iOS)
- `UXBezierPath` → `NSBezierPath` (macOS) / `UIBezierPath` (iOS)

However, these were never used. This PR replaces all UIKit-specific types with the `UX*` equivalents.

## Test plan

- [x] Verified macOS build succeeds (`swift build`)
- [x] Verified iOS build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)